### PR TITLE
Use failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Samuel Marks <@SamuelMarks>",
 edition = "2018"
 
 [dependencies]
+failure = "0.1.5"
 os_pipe = "0.8.0"
 serde = "1.0.91"
 serde_derive = "1.0.91"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,21 +1,25 @@
 /// # Fantom/libconsensus/errors
 ///
 /// This file defines a set of errors which are used within the consensus traits.
+use failure::{Error as FailureError};
 use libcommon_rs::errors::Error as BaseError;
 use libtransport::errors::Error as TransportError;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, FailureError>;
 
 /// Differentiates between multiple error types. Errors are outlined as follows:
 /// Base: A base error, as defined in the libcommon crate.
 /// AtMaxVecCapacity: Returned when a new element is added to a vector of full capacity.
 /// Transport: An error caused by a transport protocol error.
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "Base Error: {:?}", 0)]
     Base(BaseError),
     // Error indicating Vec<T> is reached maximum capacity and would cause
     // panic while adding next element.
+    #[fail(display = "Internal vector is at maximum capacity!")]
     AtMaxVecCapacity,
+    #[fail(display = "Transport Error: {:?}", 0)]
     Transport(TransportError),
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 /// # Fantom/libconsensus/errors
 ///
 /// This file defines a set of errors which are used within the consensus traits.
-use failure::{Error as FailureError};
+use failure::Error as FailureError;
 use libcommon_rs::errors::Error as BaseError;
 use libtransport::errors::Error as TransportError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
 /// For an example of an implementation of the traits, refer to the libconsensus-dag repository:
 /// https://github.com/Fantom-foundation/libconsensus-dag.
 extern crate serde_derive;
-#[macro_use] extern crate failure;
+#[macro_use]
+extern crate failure;
 use crate::errors::Result;
 use futures::stream::Stream;
 use libcommon_rs::peer::{Peer, PeerId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 /// For an example of an implementation of the traits, refer to the libconsensus-dag repository:
 /// https://github.com/Fantom-foundation/libconsensus-dag.
 extern crate serde_derive;
+#[macro_use] extern crate failure;
 use crate::errors::Result;
 use futures::stream::Stream;
 use libcommon_rs::peer::{Peer, PeerId};


### PR DESCRIPTION
I decided to temporarily leave the libcommon::Error code here to make
the transition backwards compatible and not break other people's code.